### PR TITLE
added onBeforeLoad prop so window.CKEDITOR is exposed before loading

### DIFF
--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -58,6 +58,10 @@ class CKEditor extends React.Component {
 		getEditorNamespace( CKEditor.editorUrl ).then( CKEDITOR => {
 			const constructor = this.props.type === 'inline' ? 'inline' : 'replace';
 
+			if ( this.props.onBeforeLoad ) {
+				this.props.onBeforeLoad( CKEDITOR );
+			}
+
 			const editor = this.editor = CKEDITOR[ constructor ]( this.element, this.props.config );
 
 			this._attachEventHandlers();
@@ -112,7 +116,8 @@ CKEditor.propTypes = {
 	data: PropTypes.string,
 	config: PropTypes.object,
 	style: PropTypes.object,
-	readOnly: PropTypes.bool
+	readOnly: PropTypes.bool,
+	onBeforeLoad: PropTypes.func
 };
 
 CKEditor.defaultProps = {

--- a/tests/ckeditor.jsx
+++ b/tests/ckeditor.jsx
@@ -374,6 +374,32 @@ describe( 'CKEditor Component', () => {
 			} );
 		} );
 	} );
+
+	// #18
+	describe( '#onBeforeLoad', () => {
+		it( 'receives CKEDITOR as a parameter', () => {
+			const onBeforeLoad = sandbox.spy();
+			const component = createEditor( { onBeforeLoad } );
+
+			return Promise.all( [
+				getEditorNamespace( CKEditor.editorUrl ),
+				waitForEditor( component )
+			] ).then( ( [ CKEDITOR ] ) => {
+				expect( onBeforeLoad ).to.be.calledOnceWithExactly( CKEDITOR );
+			} );
+		} );
+
+		it( 'is fired before creating editor instance', () => {
+			const onBeforeLoad = sandbox.spy();
+			const spy = sandbox.spy( CKEDITOR, 'replace' );
+			const component = createEditor( { onBeforeLoad } );
+
+			return waitForEditor( component ).then( () => {
+				expect( onBeforeLoad ).to.be.calledOnce;
+				expect( onBeforeLoad ).to.be.calledBefore( spy );
+			} );
+		} );
+	} );
 } );
 
 describe( 'getEditorNamespace', () => {


### PR DESCRIPTION
This would be useful to use things like CKEDITOR.plugins.addExternal functions before the editor is loaded.

Closes #47.