### PR TITLE
Fix for failing tests

### DIFF
--- a/tests/ckeditor.jsx
+++ b/tests/ckeditor.jsx
@@ -41,6 +41,7 @@ describe( 'CKEditor Component', () => {
 					destroyPromises.push( promise );
 				}
 
+				// Some tricky race causes failing tests delaying unmount fixes it (#21).
 				setTimeout( () => {
 					component.unmount();
 				} );

--- a/tests/ckeditor.jsx
+++ b/tests/ckeditor.jsx
@@ -189,11 +189,6 @@ describe( 'CKEditor Component', () => {
 		} );
 
 		it( 'does not throw when props are changed after unmounting component', () => {
-			// This test in Edge causes fail in afterEach hook.
-			if ( CKEDITOR.env.edge ) {
-				return;
-			}
-
 			const component = createEditor();
 
 			return waitForEditor( component ).then( () => {

--- a/tests/ckeditor.jsx
+++ b/tests/ckeditor.jsx
@@ -41,7 +41,9 @@ describe( 'CKEditor Component', () => {
 					destroyPromises.push( promise );
 				}
 
-				component.unmount();
+				setTimeout( () => {
+					component.unmount();
+				} );
 			} catch ( e ) {} // eslint-disable-line no-empty
 		} );
 


### PR DESCRIPTION
There is some tricky race happening. It is connected to test 
>does not throw when props are changed after unmounting component

Removing it solves the issue, however I found different solution, which is wrapping `component.unmount` with `setTimeout`. Additionally this solution also fixes failing test on MS Edge.

Closes #21