### PR TITLE
Added version bumping script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5267,6 +5267,12 @@
       "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
       "dev": true
     },
+    "json": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/json/-/json-9.0.6.tgz",
+      "integrity": "sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU=",
+      "dev": true
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -7209,6 +7215,15 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -7621,6 +7636,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5267,12 +5267,6 @@
       "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
       "dev": true
     },
-    "json": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/json/-/json-9.0.6.tgz",
-      "integrity": "sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU=",
-      "dev": true
-    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "eslint-plugin-react": "^7.11.1",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^4.1.0",
-    "json": "^9.0.6",
     "karma-browserstack-launcher": "^1.4.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "eslint \"src/**/*.js?(x)\" \"tests/**/*.jsx\"",
     "pretest": "npm run lint",
     "test": "karma start",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "bump": "node ./scripts/bump.js"
   },
   "repository": {
     "type": "git",
@@ -56,6 +57,7 @@
     "eslint-plugin-react": "^7.11.1",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^4.1.0",
+    "json": "^9.0.6",
     "karma-browserstack-launcher": "^1.4.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
@@ -71,6 +73,7 @@
     "react-dom": "^16.5.2",
     "react-router-dom": "^5.0.0",
     "sinon": "^7.3.2",
+    "shelljs": "^0.8.3",
     "sinon-chai": "^3.2.0",
     "terser-webpack-plugin": "^1.1.0",
     "webpack": "^4.20.2",

--- a/scripts/bump.js
+++ b/scripts/bump.js
@@ -15,18 +15,10 @@ if ( !( args && args[ 2 ] && args[ 2 ].length > 2 ) ) {
 const version = args[ 2 ];
 
 // Update CDN link in 'src/ckeditor.jsx' file.
-const jsxFilePath = path.resolve( __dirname, '..', 'src', 'ckeditor.jsx' );
-const jsxFileData = fs.readFileSync( jsxFilePath, 'utf8' );
-
-fs.writeFileSync( jsxFilePath,
-	jsxFileData.replace( /https:\/\/cdn\.ckeditor\.com\/\d\.\d+\.\d+/g, `https://cdn.ckeditor.com/${ version }` ), 'utf8' );
+updateCdnLink( path.resolve( __dirname, '..', 'src', 'ckeditor.jsx' ) );
 
 // Update CDN link in 'karma.conf.js' file.
-const karmaFilePath = path.resolve( __dirname, '..', 'karma.conf.js' );
-const karmaFileData = fs.readFileSync( karmaFilePath, 'utf8' );
-
-fs.writeFileSync( karmaFilePath,
-	karmaFileData.replace( /https:\/\/cdn\.ckeditor\.com\/\d\.\d+\.\d+/g, `https://cdn.ckeditor.com/${ version }` ), 'utf8' );
+updateCdnLink( path.resolve( __dirname, '..', 'karma.conf.js' ) );
 
 // Update 'peerDependency' in 'package.json'.
 pkg.peerDependencies.ckeditor = `^${ version }`;
@@ -34,3 +26,11 @@ fs.writeFileSync( path.resolve( __dirname, '..', 'package.json' ), JSON.stringif
 
 // Update 'devDependency' in 'package.json' file and entire 'package-lock.json' file.
 shell.exec( `npm install ckeditor@${ version } --save-dev` );
+
+function updateCdnLink( path ) {
+	const file = fs.readFileSync( path, 'utf8' );
+	const cdnLinkRegex = /https:\/\/cdn\.ckeditor\.com\/\d\.\d+\.\d+/g;
+
+	fs.writeFileSync( path,
+		file.replace( cdnLinkRegex, `https://cdn.ckeditor.com/${ version }` ), 'utf8' );
+}

--- a/scripts/bump.js
+++ b/scripts/bump.js
@@ -14,12 +14,19 @@ if ( !( args && args[ 2 ] && args[ 2 ].length > 2 ) ) {
 
 const version = args[ 2 ];
 
-// Update version in 'src/ckeditor.jsx' file.
-const filePath = './src/ckeditor.jsx';
-const fileData = fs.readFileSync( filePath, 'utf8' );
+// Update CDN link in 'src/ckeditor.jsx' file.
+const jsxFilePath = path.resolve( __dirname, '..', 'src', 'ckeditor.jsx' );
+const jsxFileData = fs.readFileSync( jsxFilePath, 'utf8' );
 
-fs.writeFileSync( filePath,
-	fileData.replace( /https:\/\/cdn\.ckeditor\.com\/\d\.\d+\.\d+/g, `https://cdn.ckeditor.com/${ version }` ), 'utf8' );
+fs.writeFileSync( jsxFilePath,
+	jsxFileData.replace( /https:\/\/cdn\.ckeditor\.com\/\d\.\d+\.\d+/g, `https://cdn.ckeditor.com/${ version }` ), 'utf8' );
+
+// Update CDN link in 'karma.conf.js' file.
+const karmaFilePath = path.resolve( __dirname, '..', 'karma.conf.js' );
+const karmaFileData = fs.readFileSync( karmaFilePath, 'utf8' );
+
+fs.writeFileSync( karmaFilePath,
+	karmaFileData.replace( /https:\/\/cdn\.ckeditor\.com\/\d\.\d+\.\d+/g, `https://cdn.ckeditor.com/${ version }` ), 'utf8' );
 
 // Update 'peerDependency' in 'package.json'.
 pkg.peerDependencies.ckeditor = `^${ version }`;

--- a/scripts/bump.js
+++ b/scripts/bump.js
@@ -1,25 +1,29 @@
-/* global process, require */
+/* global process, require, __dirname */
 
 const fs = require( 'fs' );
+const path = require( 'path' );
 const shell = require( 'shelljs' );
+const pkg = require( '../package.json' );
 
 const args = process.argv;
 
 if ( !( args && args[ 2 ] && args[ 2 ].length > 2 ) ) {
-	console.log( 'Missing CKEditor version! USAGE: npm run bump -- A.B.C, for example: npm run bump -- 4.11.5' );
-} else {
-	const version = args[ 2 ];
-
-	// Update version in 'src/ckeditor.jsx' file.
-	const filePath = './src/ckeditor.jsx';
-	const fileData = fs.readFileSync( filePath, 'utf8' );
-
-	fs.writeFileSync( filePath,
-		fileData.replace( /https:\/\/cdn\.ckeditor\.com\/\d\.\d+\.\d+/g, `https://cdn.ckeditor.com/${ version }` ), 'utf8' );
-
-	// Update 'peerDependency' in 'package.json'. See `json` package docs - http://trentm.com/json.
-	shell.exec( `./node_modules/json/lib/json.js -I -f package.json -e 'this.peerDependencies.ckeditor="^${ version }"'` );
-
-	// Update 'devDependency' in 'package.json' file and entire 'package-lock.json' file.
-	shell.exec( `npm install ckeditor@${ version } --save-dev` );
+	console.error( 'Missing CKEditor version! USAGE: npm run bump A.B.C, for example: npm run bump 4.11.5' );
+	process.exit( 1 );
 }
+
+const version = args[ 2 ];
+
+// Update version in 'src/ckeditor.jsx' file.
+const filePath = './src/ckeditor.jsx';
+const fileData = fs.readFileSync( filePath, 'utf8' );
+
+fs.writeFileSync( filePath,
+	fileData.replace( /https:\/\/cdn\.ckeditor\.com\/\d\.\d+\.\d+/g, `https://cdn.ckeditor.com/${ version }` ), 'utf8' );
+
+// Update 'peerDependency' in 'package.json'.
+pkg.peerDependencies.ckeditor = `^${ version }`;
+fs.writeFileSync( path.resolve( __dirname, '..', 'package.json' ), JSON.stringify( pkg, null, '  ' ) );
+
+// Update 'devDependency' in 'package.json' file and entire 'package-lock.json' file.
+shell.exec( `npm install ckeditor@${ version } --save-dev` );

--- a/scripts/bump.js
+++ b/scripts/bump.js
@@ -1,0 +1,25 @@
+/* global process, require */
+
+const fs = require( 'fs' );
+const shell = require( 'shelljs' );
+
+const args = process.argv;
+
+if ( !( args && args[ 2 ] && args[ 2 ].length > 2 ) ) {
+	console.log( 'Missing CKEditor version! USAGE: npm run bump -- A.B.C, for example: npm run bump -- 4.11.5' );
+} else {
+	const version = args[ 2 ];
+
+	// Update version in 'src/ckeditor.jsx' file.
+	const filePath = './src/ckeditor.jsx';
+	const fileData = fs.readFileSync( filePath, 'utf8' );
+
+	fs.writeFileSync( filePath,
+		fileData.replace( /https:\/\/cdn\.ckeditor\.com\/\d\.\d+\.\d+/g, `https://cdn.ckeditor.com/${ version }` ), 'utf8' );
+
+	// Update 'peerDependency' in 'package.json'. See `json` package docs - http://trentm.com/json.
+	shell.exec( `./node_modules/json/lib/json.js -I -f package.json -e 'this.peerDependencies.ckeditor="^${ version }"'` );
+
+	// Update 'devDependency' in 'package.json' file and entire 'package-lock.json' file.
+	shell.exec( `npm install ckeditor@${ version } --save-dev` );
+}


### PR DESCRIPTION
I have added script for automatically bumping all references to `ckeditor` package. Usage:

```
npm run bump version
npm run bump 4.11.5
```

I know that such scripts can be created in many, many ways (was thinking about bash only) but as we mostly code in JS, nodejs seems to be safe option so everybody can easily understand and modify the script if needed.

Closes #29.