### PR TITLE
Add displayName for easy debugging and testing

### DIFF
--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -123,5 +123,6 @@ CKEditor.defaultProps = {
 };
 
 CKEditor.editorUrl = 'https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js';
+CKEditor.displayName = 'CKEditor';
 
 export default CKEditor;

--- a/tests/ckeditor.jsx
+++ b/tests/ckeditor.jsx
@@ -59,6 +59,11 @@ describe( 'CKEditor Component', () => {
 		} );
 	} );
 
+	// (#48)
+	it( 'has proper displayName property', () => {
+		expect( CKEditor.displayName ).to.equal( 'CKEditor' );
+	} );
+
 	describe( 'mounting and types', () => {
 		it( 'calls CKEDITOR.replace on mount', () => {
 			sandbox.spy( CKEDITOR, 'replace' );


### PR DESCRIPTION
As you export CKEditor with default export, when Webpack minify the code it rename CKEditor class with random letter.

Have a nice day :)