### PR TITLE
Restrict CI build of branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,15 @@ addons:
   chrome: stable
   firefox: latest
 
+branches:
+  only:
+  - master
+  - major
+  - stable
+  - latest
+  - /^\d+\.\d+(\.\d+)?(-\S*)?$/
+  - /^release\/\d+\.\d+\.x$/
+
 language: node_js
 node_js:
   - 10


### PR DESCRIPTION
I've added safelist of branches to `.travis.yml` to trigger builds only on main and stable branches.

Closes #64.