### PR TITLE
Fix for editor-element-config error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CKEditor 4 WYSIWYG Editor React Integration Changelog
 
+## ckeditor4-react 1.0.2
+
+Fixed Issues:
+
+* [#57](https://github.com/ckeditor/ckeditor4-react/issues/57): Fixed: CKEditor4 React integration gives [`editor-element-conflict` error](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_errors.html#editor-element-conflict).
+
 ## ckeditor4-react 1.0.1
 
 Other Changes:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,7 +17,6 @@ module.exports = function( config ) {
 		frameworks: [ 'mocha', 'chai', 'sinon' ],
 
 		files: [
-			'https://cdn.ckeditor.com/4.13.1/standard-all/ckeditor.js',
 			'tests/browser/**/*.jsx'
 		],
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -118,6 +118,12 @@ module.exports = function( config ) {
 
 		mochaReporter: {
 			showDiff: true
+		},
+
+		client: {
+			mocha: {
+				timeout: 5000
+			}
 		}
 	} );
 };

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -51,34 +51,35 @@ class CKEditor extends React.Component {
 	}
 
 	_initEditor() {
-		this.props.config.readOnly = this.props.readOnly;
+		const { config, readOnly, type, onBeforeLoad, style, data } = this.props;
+		config.readOnly = readOnly;
 
 		getEditorNamespace( CKEditor.editorUrl ).then( CKEDITOR => {
-			const constructor = this.props.type === 'inline' ? 'inline' : 'replace';
+			const constructor = type === 'inline' ? 'inline' : 'replace';
 
-			if ( this.props.onBeforeLoad ) {
-				this.props.onBeforeLoad( CKEDITOR );
+			if ( onBeforeLoad ) {
+				onBeforeLoad( CKEDITOR );
 			}
 
 			// We must force editability of inline editor to prevent
 			// element-conflict error. Can't to it via config due to
 			// upstream bug in CKE (#57, ckeditor/ckeditor4#3866).
-			if ( this.props.type === 'inline' && !this.props.readOnly ) {
+			if ( type === 'inline' && !readOnly ) {
 				this.element.contentEditable = true;
 			}
 
-			const editor = this.editor = CKEDITOR[ constructor ]( this.element, this.props.config );
+			const editor = this.editor = CKEDITOR[ constructor ]( this.element, config );
 
 			this._attachEventHandlers();
 
-			if ( this.props.style && this.props.type !== 'inline' ) {
+			if ( style && type !== 'inline' ) {
 				editor.on( 'loaded', () => {
-					editor.container.setStyles( this.props.style );
+					editor.container.setStyles( style );
 				} );
 			}
 
-			if ( this.props.data ) {
-				editor.setData( this.props.data );
+			if ( data ) {
+				editor.setData( data );
 			}
 		} ).catch( console.error );
 	}

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -61,16 +61,18 @@ class CKEditor extends React.Component {
 				onBeforeLoad( CKEDITOR );
 			}
 
+			const editor = this.editor = CKEDITOR[ constructor ]( this.element, config );
+
+			this._attachEventHandlers();
+
 			// We must force editability of inline editor to prevent
 			// element-conflict error. Can't to it via config due to
 			// upstream bug in CKE (#57, ckeditor/ckeditor4#3866).
 			if ( type === 'inline' && !readOnly ) {
-				this.element.contentEditable = true;
+				editor.on( 'instanceReady', () => {
+					editor.setReadOnly( false );
+				}, null, null, -1 );
 			}
-
-			const editor = this.editor = CKEDITOR[ constructor ]( this.element, config );
-
-			this._attachEventHandlers();
 
 			if ( style && type !== 'inline' ) {
 				editor.on( 'loaded', () => {

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -60,6 +60,13 @@ class CKEditor extends React.Component {
 				this.props.onBeforeLoad( CKEDITOR );
 			}
 
+			// We must force editability of inline editor to prevent
+			// element-conflict error. Can't to it via config due to
+			// upstream bug in CKE (#57, ckeditor/ckeditor4#3866).
+			if ( this.props.type === 'inline' && !this.props.readOnly ) {
+				this.element.contentEditable = true;
+			}
+
 			const editor = this.editor = CKEDITOR[ constructor ]( this.element, this.props.config );
 
 			this._attachEventHandlers();

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -47,7 +47,7 @@ class CKEditor extends React.Component {
 	}
 
 	render() {
-		return <div contentEditable="true" style={ this.props.style } ref={ ref => ( this.element = ref ) }></div>;
+		return <div style={ this.props.style } ref={ ref => ( this.element = ref ) }></div>;
 	}
 
 	_initEditor() {

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -65,9 +65,8 @@ class CKEditor extends React.Component {
 
 			this._attachEventHandlers();
 
-			// We must force editability of inline editor to prevent
-			// element-conflict error. Can't to it via config due to
-			// upstream bug in CKE (#57, ckeditor/ckeditor4#3866).
+			// We must force editability of the inline editor to prevent `element-conflict` error.
+			// It can't be done via config due to CKEditor 4 upstream issue (#57, ckeditor/ckeditor4#3866).
 			if ( type === 'inline' && !readOnly ) {
 				editor.on( 'instanceReady', () => {
 					editor.setReadOnly( false );

--- a/tests/browser/ckeditor.jsx
+++ b/tests/browser/ckeditor.jsx
@@ -19,6 +19,8 @@ configure( { adapter: new Adapter() } );
 
 let components = [];
 
+CKEditor.editorUrl = 'https://cdn.ckeditor.com/4.13.1/standard-all/ckeditor.js';
+
 describe( 'CKEditor Component', () => {
 	let sandbox;
 
@@ -65,6 +67,18 @@ describe( 'CKEditor Component', () => {
 	} );
 
 	describe( 'mounting and types', () => {
+		// This test must run as the first one, as it depends on resolving
+		// the CKEditor namespace (#57)!
+		it( 'does not raise element-conflict error', () => {
+			sandbox.spy( console, 'error' );
+
+			const component = createEditor();
+
+			return waitForEditor( component ).then( () => {
+				expect( console.error ).not.to.be.called;
+			} );
+		} );
+
 		it( 'calls CKEDITOR.replace on mount', () => {
 			sandbox.spy( CKEDITOR, 'replace' );
 

--- a/tests/server/ckeditor.jsx
+++ b/tests/server/ckeditor.jsx
@@ -13,7 +13,7 @@ import CKEditorBuilt from '../../dist/ckeditor.js';
 describe( 'CKEditor Component SSR', () => {
 	describe( 'basic rendering', () => {
 		createTest( 'returns appropriate HTML', CKEditor => {
-			const expected = '<div contenteditable="true" data-reactroot=""></div>';
+			const expected = '<div data-reactroot=""></div>';
 			const rendered = ReactDOMServer.renderToString( <CKEditor /> );
 
 			expect( rendered ).to.equal( expected );


### PR DESCRIPTION
It seems that simple removal of `[contenteditable=true]` attribute resolves the issue. However it also forces to add workaround for inline editors to force editable state (see ckeditor/ckeditor4#3866).

Closes #57.