### PR TITLE
fix: prevent 'editor-incorrect-element' error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CKEditor 4 WYSIWYG Editor React Integration Changelog
 
+## ckeditor4-react 1.1.2
+
+Fixed Issues:
+
+* [#94](https://github.com/ckeditor/ckeditor4-react/issues/94): Fixed: The [`editor-incorrect-element`](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_errors.html#editor-incorrect-element) error is thrown due to `null` element reference when editor instance is destroyed before initialization completes. Thanks to [Christoph Dörfel](https://github.com/Garbanas)!
+
 ## ckeditor4-react 1.1.1
 
 Other Changes:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -110,7 +110,7 @@ module.exports = function( config ) {
 			project: 'ckeditor4'
 		},
 
-		singleRun: true,
+		singleRun: false,
 
 		concurrency: Infinity,
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -110,7 +110,7 @@ module.exports = function( config ) {
 			project: 'ckeditor4'
 		},
 
-		singleRun: false,
+		singleRun: true,
 
 		concurrency: Infinity,
 

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -63,7 +63,7 @@ class CKEditor extends React.Component {
 
 			// (#94)
 			if ( !this.element ) {
-				throw new Error( 'Element ref not available for mounting CKEDITOR instance' );
+				throw new Error( 'Element not available for mounting CKEDITOR instance.' );
 			}
 
 			const constructor = type === 'inline' ? 'inline' : 'replace';

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -60,6 +60,10 @@ class CKEditor extends React.Component {
 				return;
 			}
 
+			if ( !this.element ) {
+				throw new Error( 'Element ref not available for mounting CKEDITOR instance' );
+			}
+
 			const constructor = type === 'inline' ? 'inline' : 'replace';
 
 			if ( onBeforeLoad ) {

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -60,10 +60,6 @@ class CKEditor extends React.Component {
 				return;
 			}
 
-			if ( !this.element ) {
-				throw new Error( 'Element ref not available for mounting CKEDITOR instance' );
-			}
-
 			const constructor = type === 'inline' ? 'inline' : 'replace';
 
 			if ( onBeforeLoad ) {

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -13,6 +13,7 @@ class CKEditor extends React.Component {
 
 		this.element = null;
 		this.editor = null;
+		this._destroyed = false;
 	}
 
 	componentDidMount() {
@@ -55,6 +56,14 @@ class CKEditor extends React.Component {
 		config.readOnly = readOnly;
 
 		getEditorNamespace( CKEditor.editorUrl ).then( CKEDITOR => {
+			if ( this._destroyed ) {
+				return;
+			}
+
+			if ( !this.element ) {
+				throw new Error( 'Element ref not available for mounting CKEDITOR instance' );
+			}
+
 			const constructor = type === 'inline' ? 'inline' : 'replace';
 
 			if ( onBeforeLoad ) {
@@ -114,6 +123,7 @@ class CKEditor extends React.Component {
 
 		this.editor = null;
 		this.element = null;
+		this._destroyed = true;
 	}
 }
 

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -56,10 +56,12 @@ class CKEditor extends React.Component {
 		config.readOnly = readOnly;
 
 		getEditorNamespace( CKEditor.editorUrl ).then( CKEDITOR => {
+			// (#94)
 			if ( this._destroyed ) {
 				return;
 			}
 
+			// (#94)
 			if ( !this.element ) {
 				throw new Error( 'Element ref not available for mounting CKEDITOR instance' );
 			}

--- a/tests/browser/ckeditor.jsx
+++ b/tests/browser/ckeditor.jsx
@@ -172,7 +172,7 @@ describe( 'CKEditor Component', () => {
 				resolve();
 			} ).then( () => {
 				expect( console.error ).to.be.called;
-			} ).catch( err => {} );
+			} ).catch( err => {} ); // eslint-disable-line no-unused-vars
 		} );
 
 		it( 'saves references to the editor and element', () => {

--- a/tests/browser/ckeditor.jsx
+++ b/tests/browser/ckeditor.jsx
@@ -146,7 +146,7 @@ describe( 'CKEditor Component', () => {
 		} );
 
 		// (#94)
-		it( 'does not throw error when editor element removed before mount is finished', () => {
+		it( 'does not throw CKEDITOR.error() when editor element removed before mount is finished', () => {
 			sandbox.spy( CKEDITOR, 'error' );
 
 			const component = createEditor();
@@ -158,6 +158,21 @@ describe( 'CKEditor Component', () => {
 			} ).then( () => {
 				expect( CKEDITOR.error ).not.to.be.called;
 			} );
+		} );
+
+		// (#94)
+		it( 'throws console error when editor element removed before mount is finished', () => {
+			sandbox.spy( console, 'error' );
+
+			const component = createEditor();
+			const componentInstance = component.instance();
+
+			return new Promise( resolve => {
+				componentInstance.element = null;
+				resolve();
+			} ).then( () => {
+				expect( console.error ).to.be.called;
+			} ).catch( err => {} );
 		} );
 
 		it( 'saves references to the editor and element', () => {

--- a/tests/browser/ckeditor.jsx
+++ b/tests/browser/ckeditor.jsx
@@ -148,6 +148,7 @@ describe( 'CKEditor Component', () => {
 		// (#94)
 		it( 'does not throw CKEDITOR.error() when editor element removed before mount is finished', () => {
 			sandbox.spy( CKEDITOR, 'error' );
+			sandbox.stub( console, 'error' );
 
 			const component = createEditor();
 			const componentInstance = component.instance();
@@ -162,7 +163,7 @@ describe( 'CKEditor Component', () => {
 
 		// (#94)
 		it( 'throws console error when editor element removed before mount is finished', () => {
-			sandbox.spy( console, 'error' );
+			sandbox.stub( console, 'error' );
 
 			const component = createEditor();
 			const componentInstance = component.instance();

--- a/tests/browser/ckeditor.jsx
+++ b/tests/browser/ckeditor.jsx
@@ -125,6 +125,19 @@ describe( 'CKEditor Component', () => {
 			} );
 		} );
 
+		it( 'destroys editor before mount is finished', () => {
+			sandbox.spy( CKEDITOR, 'error' );
+
+			const component = createEditor();
+
+			return new Promise( resolve => {
+				component.unmount();
+				resolve();
+			} ).then( () => {
+				expect( CKEDITOR.error ).not.to.be.called;
+			} );
+		} );
+
 		it( 'saves references to the editor and element', () => {
 			const component = createEditor();
 			const componentInstance = component.instance();

--- a/tests/browser/ckeditor.jsx
+++ b/tests/browser/ckeditor.jsx
@@ -54,9 +54,15 @@ describe( 'CKEditor Component', () => {
 			components = [];
 			sandbox.restore();
 
-			const containers = document.querySelectorAll( 'div' );
-			containers.forEach( container => {
-				document.body.removeChild( container );
+			return new Promise( resolve => {
+				setTimeout( () => {
+					const containers = document.querySelectorAll( 'div' );
+					containers.forEach( container => {
+						document.body.removeChild( container );
+					} );
+
+					resolve();
+				} );
 			} );
 		} );
 	} );
@@ -125,13 +131,27 @@ describe( 'CKEditor Component', () => {
 			} );
 		} );
 
-		it( 'destroys editor before mount is finished', () => {
+		it( 'does not throw error when editor destroyed before mount is finished', () => {
 			sandbox.spy( CKEDITOR, 'error' );
 
 			const component = createEditor();
 
 			return new Promise( resolve => {
 				component.unmount();
+				resolve();
+			} ).then( () => {
+				expect( CKEDITOR.error ).not.to.be.called;
+			} );
+		} );
+
+		it( 'does not throw error when editor element removed before mount is finished', () => {
+			sandbox.spy( CKEDITOR, 'error' );
+
+			const component = createEditor();
+			const componentInstance = component.instance();
+
+			return new Promise( resolve => {
+				componentInstance.element = null;
 				resolve();
 			} ).then( () => {
 				expect( CKEDITOR.error ).not.to.be.called;

--- a/tests/browser/ckeditor.jsx
+++ b/tests/browser/ckeditor.jsx
@@ -131,6 +131,7 @@ describe( 'CKEditor Component', () => {
 			} );
 		} );
 
+		// (#94)
 		it( 'does not throw error when editor destroyed before mount is finished', () => {
 			sandbox.spy( CKEDITOR, 'error' );
 
@@ -144,6 +145,7 @@ describe( 'CKEditor Component', () => {
 			} );
 		} );
 
+		// (#94)
 		it( 'does not throw error when editor element removed before mount is finished', () => {
 			sandbox.spy( CKEDITOR, 'error' );
 


### PR DESCRIPTION
This fixes issues when trying to initialize the editor on an element that has
already been destroyed after completing a long running promise.

Closes #94.