### PR TITLE
Use the freshest data on mount.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage/
 dist/
 sample/dist/
 react-tests/
+*debug.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CKEditor 4 WYSIWYG Editor React Integration Changelog
 
+## ckeditor4-react 1.5.0
+
+Fixed Issues:
+
+* [#114](https://github.com/ckeditor/ckeditor4-react/issues/114), [#127](https://github.com/ckeditor/ckeditor4-react/issues/127): Fixed: The editor uses initial stale data if `data` property changed before editor reaches [`instanceReady` state](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#event-instanceReady).
+
 ## ckeditor4-react 1.4.0
 
 Other Changes:

--- a/samples/main.js
+++ b/samples/main.js
@@ -1,4 +1,4 @@
-const { useState } = React;
+const { useState, useEffect } = React;
 const { HashRouter, Switch, Route, Link } = ReactRouterDOM;
 
 const startingData = '<p>This is a CKEditor 4 WYSIWYG editor instance created by ️⚛️ React.</p>';
@@ -18,6 +18,7 @@ function Navigation() {
 				<Link to="/">Editor Types</Link>
 				<Link to="/events">Component Events</Link>
 				<Link to="/binding">Two-way Data Binding</Link>
+				<Link to="/data-prop">Data Prop Changes</Link>
 			</li>
 		</ul>
 	);
@@ -34,6 +35,9 @@ function Router() {
 			</Route>
 			<Route path="/binding">
 				<EditorTwoWayDataBinding />
+			</Route>
+			<Route path="/data-prop">
+				<EditorDataPropChanges />
 			</Route>
 		</Switch>
 	);
@@ -74,6 +78,55 @@ function EditorTypes() {
 					Read-only
 				</label>
 			</p>
+		</main>
+	);
+}
+
+function EditorDataPropChanges() {
+	const [ data, setData ] = useState( startingData );
+
+	useEffect( () => {
+		setTimeout( function() {
+			setData( 'Waiting for data...' );
+		}, 0 );
+	}, [] );
+
+	useEffect( () => {
+		setTimeout( function() {
+			setData( 'Data arrived!' );
+		}, 3000 );
+	}, [] );
+
+	const generateData = () => {
+		setData( `Passed new data: ${ new Date().getTime() }` );
+	};
+
+	return (
+		<main>
+			<h2>Data Prop Changes</h2>
+			<p>
+				Editor component will show the freshest data set via `data` prop once the editor is ready.
+			</p>
+			<section>
+				<h3>Generate data</h3>
+				<button onClick={ generateData }>Set `data` prop</button>
+			</section>
+			<section>
+				<h3>Classic editor</h3>
+				<CKEditor
+					type="classic"
+					data={ data }
+					onNamespaceLoaded={ onNamespaceLoaded }
+				/>
+			</section>
+			<section>
+				<h3>Inline editor</h3>
+				<CKEditor
+					type="inline"
+					data={ data }
+					onNamespaceLoaded={ onNamespaceLoaded }
+				/>
+			</section>
 		</main>
 	);
 }

--- a/samples/main.js
+++ b/samples/main.js
@@ -82,56 +82,6 @@ function EditorTypes() {
 	);
 }
 
-function EditorDataPropChanges() {
-	const [ data, setData ] = useState( startingData );
-
-	useEffect( () => {
-		const fakeApi = () => {
-			timeout( 50 ).then( () => {
-				setData( 'Init data arrived!' );
-				return timeout( 3000 );
-			} ).then( () => {
-				setData( 'Final data arrived!' );
-			} );
-		};
-
-		fakeApi();
-	}, [] );
-
-	const generateData = () => {
-		setData( `Passed new data: ${ new Date().getTime() }` );
-	};
-
-	return (
-		<main>
-			<h2>Data Prop Changes</h2>
-			<p>
-				Editor component will show the freshest data set via `data` prop once the editor is ready.
-			</p>
-			<section>
-				<h3>Generate data</h3>
-				<button onClick={ generateData }>Set `data` prop</button>
-			</section>
-			<section>
-				<h3>Classic editor</h3>
-				<CKEditor
-					type="classic"
-					data={ data }
-					onNamespaceLoaded={ onNamespaceLoaded }
-				/>
-			</section>
-			<section>
-				<h3>Inline editor</h3>
-				<CKEditor
-					type="inline"
-					data={ data }
-					onNamespaceLoaded={ onNamespaceLoaded }
-				/>
-			</section>
-		</main>
-	);
-}
-
 function EditorEvents() {
 	const [ events, setEvents ] = useState( [] );
 
@@ -257,6 +207,56 @@ function EditorPreview( { data } ) {
 			<h2>Rendered content</h2>
 			<div dangerouslySetInnerHTML={ { __html: data } }></div>
 		</div>
+	);
+}
+
+function EditorDataPropChanges() {
+	const [ data, setData ] = useState( startingData );
+
+	useEffect( () => {
+		const fakeApi = () => {
+			timeout( 50 ).then( () => {
+				setData( 'Init data arrived!' );
+				return timeout( 3000 );
+			} ).then( () => {
+				setData( 'Final data arrived!' );
+			} );
+		};
+
+		fakeApi();
+	}, [] );
+
+	const generateData = () => {
+		setData( `Passed new data: ${ new Date().getTime() }` );
+	};
+
+	return (
+		<main>
+			<h2>Data Prop Changes</h2>
+			<p>
+				Editor component will show the freshest data set via `data` prop once the editor is ready.
+			</p>
+			<section>
+				<h3>Generate data</h3>
+				<button onClick={ generateData }>Set `data` prop</button>
+			</section>
+			<section>
+				<h3>Classic editor</h3>
+				<CKEditor
+					type="classic"
+					data={ data }
+					onNamespaceLoaded={ onNamespaceLoaded }
+				/>
+			</section>
+			<section>
+				<h3>Inline editor</h3>
+				<CKEditor
+					type="inline"
+					data={ data }
+					onNamespaceLoaded={ onNamespaceLoaded }
+				/>
+			</section>
+		</main>
 	);
 }
 

--- a/samples/main.js
+++ b/samples/main.js
@@ -86,15 +86,16 @@ function EditorDataPropChanges() {
 	const [ data, setData ] = useState( startingData );
 
 	useEffect( () => {
-		setTimeout( function() {
-			setData( 'Waiting for data...' );
-		}, 0 );
-	}, [] );
+		const fakeApi = () => {
+			timeout( 50 ).then( () => {
+				setData( 'Init data arrived!' );
+				return timeout( 3000 );
+			} ).then( () => {
+				setData( 'Final data arrived!' );
+			} );
+		};
 
-	useEffect( () => {
-		setTimeout( function() {
-			setData( 'Data arrived!' );
-		}, 3000 );
+		fakeApi();
 	}, [] );
 
 	const generateData = () => {
@@ -271,6 +272,12 @@ function debounce( fn, wait ) {
 			fn.apply( context, args );
 		}, wait );
 	};
+}
+
+function timeout( t ) {
+	return new Promise( resolve => {
+		setTimeout( resolve, t );
+	} );
 }
 
 function onNamespaceLoaded( namespace ) {

--- a/samples/main.js
+++ b/samples/main.js
@@ -274,9 +274,9 @@ function debounce( fn, wait ) {
 	};
 }
 
-function timeout( t ) {
+function timeout( time ) {
 	return new Promise( resolve => {
-		setTimeout( resolve, t );
+		setTimeout( resolve, time );
 	} );
 }
 

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -84,7 +84,8 @@ class CKEditor extends React.Component {
 				}, null, null, -1 );
 			}
 
-			// Make sure that the freshest data is read from props when editor is ready (#114, #127).
+			// (#114, #127)
+			// Make sure that the freshest data is read from props when editor is ready.
 			editor.on( 'instanceReady', () => {
 				const data = this.props.data;
 

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -84,16 +84,19 @@ class CKEditor extends React.Component {
 				}, null, null, -1 );
 			}
 
+			// Make sure that the freshest data is read from props when editor is ready (#114, #127).
+			editor.on( 'instanceReady', () => {
+				const data = this.props.data;
+
+				if ( data ) {
+					editor.setData( data );
+				}
+			}, null, null, -1 );
+
 			if ( style && type !== 'inline' ) {
 				editor.on( 'loaded', () => {
 					editor.container.setStyles( style );
 				} );
-			}
-
-			const data = this.props.data;
-
-			if ( data ) {
-				editor.setData( data );
 			}
 		} ).catch( console.error );
 	}

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -52,7 +52,7 @@ class CKEditor extends React.Component {
 	}
 
 	_initEditor() {
-		const { config, readOnly, type, onBeforeLoad, onNamespaceLoaded, style, data } = this.props;
+		const { config, readOnly, type, onBeforeLoad, onNamespaceLoaded, style } = this.props;
 		config.readOnly = readOnly;
 
 		getEditorNamespace( CKEditor.editorUrl, onNamespaceLoaded ).then( CKEDITOR => {
@@ -89,6 +89,8 @@ class CKEditor extends React.Component {
 					editor.container.setStyles( style );
 				} );
 			}
+
+			const data = this.props.data;
 
 			if ( data ) {
 				editor.setData( data );

--- a/tests/browser/ckeditor.jsx
+++ b/tests/browser/ckeditor.jsx
@@ -278,6 +278,22 @@ describe( 'CKEditor Component', () => {
 				} );
 			} );
 		} );
+
+		it( 'uses the freshest data on mount', () => {
+			const initialData = '<p>Initial data</p>';
+			const changedData = '<p>Changed data</p>';
+			const component = createEditor( {
+				data: initialData
+			} );
+
+			component.setProps( {
+				data: changedData
+			} );
+
+			return waitForEditor( component ).then( editor => {
+				expect( editor.getData().trim() ).to.equal( changedData );
+			} );
+		} );
 	} );
 
 	describe( '#config', () => {

--- a/tests/browser/ckeditor.jsx
+++ b/tests/browser/ckeditor.jsx
@@ -277,6 +277,7 @@ describe( 'CKEditor Component', () => {
 			} );
 		} );
 
+		// (#114, #127)
 		it( 'uses the freshest data - component mounted, editor not loaded', () => {
 			const initialData = '<p>Initial data</p>';
 			const changedData = '<p>Changed data</p>';
@@ -284,7 +285,7 @@ describe( 'CKEditor Component', () => {
 				data: initialData
 			} );
 
-			// Component is already mounted, editor is not loaded, `data` prop changes
+			// Component is already mounted, editor is not loaded, `data` prop changes.
 			component.setProps( {
 				data: changedData
 			} );
@@ -298,6 +299,7 @@ describe( 'CKEditor Component', () => {
 			} );
 		} );
 
+		// (#114, #127)
 		it( 'uses the freshest data on mount - component mounted, editor loaded', () => {
 			const initialData = '<p>Initial data</p>';
 			const changedData = '<p>Changed data</p>';
@@ -306,7 +308,7 @@ describe( 'CKEditor Component', () => {
 				data: initialData
 			} );
 
-			// Component is already mounted, editor is not loaded, `data` prop changes
+			// Component is already mounted, editor is not loaded, `data` prop changes.
 			component.setProps( {
 				data: changedData
 			} );
@@ -314,7 +316,7 @@ describe( 'CKEditor Component', () => {
 			return waitForEditor( component, 'loaded' ).then( editor => {
 				sandbox.spy( editor, 'setData' );
 
-				// Component is already mounted, editor is loaded but not ready, `data` prop changes again
+				// Component is already mounted, editor is loaded but not ready, `data` prop changes again.
 				component.setProps( {
 					data: changedDataNext
 				} );


### PR DESCRIPTION
I've reproduced the described bug via a new test case. The issue was fixed by reading `data`  after `editor` initialization.

The bug can be also reproduced by slightly altering `EditorTypes` component inside `samples/main.js` file:

```
const [ data, setData ] = useState( startingData );
const [ readOnly, setReadOnly ] = useState( false );

React.useEffect( () => {
	setData( 'Test' );
}, [] );

// pass `data` as a prop
...
```

Please note that I haven't moved the whole props destructuring to `then` callback as some of the props must be read beforehand.

Closes #114.
Closes #127.