### PR TITLE
Fix BrowserStack / Safari timeout.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,7 +17,8 @@ module.exports = function( config ) {
 		frameworks: [ 'mocha', 'chai', 'sinon' ],
 
 		files: [
-			// Added as dependency here, so that script is preloaded before tests start (#185)
+			// (#185)
+			// Added as dependency here, so that script is preloaded before tests start.
 			'https://cdn.ckeditor.com/4.16.0/standard-all/ckeditor.js',
 			'tests/browser/**/*.jsx'
 		],
@@ -124,8 +125,9 @@ module.exports = function( config ) {
 
 		client: {
 			mocha: {
+				// (#185)
 				// Timeout should be accomodated to the needs of each environment (local, BrowserStack).
-				// Every browser must have a chance to bootstrap (#185).
+				// Every browser must have a chance to bootstrap.
 				timeout: 7500
 			}
 		}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,6 +17,8 @@ module.exports = function( config ) {
 		frameworks: [ 'mocha', 'chai', 'sinon' ],
 
 		files: [
+			// Added as dependency here, so that script is preloaded before tests start (#185)
+			'https://cdn.ckeditor.com/4.16.0/standard-all/ckeditor.js',
 			'tests/browser/**/*.jsx'
 		],
 
@@ -122,7 +124,9 @@ module.exports = function( config ) {
 
 		client: {
 			mocha: {
-				timeout: 5000
+				// Timeout should be accomodated to the needs of each environment (local, BrowserStack).
+				// Every browser must have a chance to bootstrap (#185).
+				timeout: 7500
 			}
 		}
 	} );


### PR DESCRIPTION
Let me enumerate a couple of initial observations:

1. The issue is observed for BrowserStack browsers (Safari and Edge).
2. The timeout issue occurs for the first test case that involves editor loading, i.e. `does not raise element-conflict error`. 
3. There seems to be no specific React version associated with this bug.

I did some debugging locally with BrowserStack and I noticed that on Safari (and sometimes on Edge too), the test case `does not raise element-conflict error` got stuck inside `waitForEditor`'s `tick` function. Time measurements revealed that it took several seconds before `editor` instance is available for the component and that was the bottleneck.

It looks like the process of loading and processing an external script via a BrowserStack browser is quite slow. I'm not sure if we can improve that somehow or that it is just slow due to BrowserStack's infrastructure, firewalls, etc.

For now I'm proposing two small adjustments to `karma.conf.js`:

1. Load ckeditor script as dependency, so that a browser on BrowserStack can at least cache that script for subsequent tests.
2. Increase `timeout` to provide a safer margin.

Closes #185.