### PR TITLE
Use requested React version

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,6 +5,7 @@
 
 /* global process, require, module */
 
+const webpack = require( 'webpack' );
 const { join: joinPath } = require( 'path' );
 
 const basePath = process.cwd();
@@ -70,7 +71,15 @@ module.exports = function( config ) {
 						}
 					}
 				]
-			}
+			},
+
+			plugins: [
+				new webpack.DefinePlugin( {
+					'process.env.REQUESTED_REACT_VERSION': JSON.stringify(
+						process.env.REQUESTED_REACT_VERSION
+					)
+				} )
+			]
 		},
 
 		webpackMiddleware: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -76,7 +76,7 @@ module.exports = function( config ) {
 			plugins: [
 				new webpack.DefinePlugin( {
 					'process.env.REQUESTED_REACT_VERSION': JSON.stringify(
-						process.env.REQUESTED_REACT_VERSION
+						process.env.REQUESTED_REACT_VERSION || ''
 					)
 				} )
 			]

--- a/scripts/react-tester.js
+++ b/scripts/react-tester.js
@@ -13,7 +13,8 @@ const semverMinor = require( 'semver/functions/minor' );
  * Commands:
  *
  * --browser <name>   Specifies environment to test.
- *                    Possible values: 'Chrome', 'Firefox', 'BrowserStack_Safari', 'BrowserStack_Edge', 'BrowserStack_IE11', 'SSR'. Defaults to: 'Chrome'.
+ *                    Possible values: 'Chrome', 'Firefox', 'BrowserStack_Safari', 'BrowserStack_Edge', 'BrowserStack_IE11', 'SSR'.
+ *                    Defaults to: 'Chrome'.
  * --react <version>  Specifies react version to test. Possible values: 'all', 'current' or specific version. Defaults to: 'current'.
  *
  */
@@ -153,7 +154,10 @@ function isLatestPatch( index, array ) {
 function prepareTestDir( version ) {
 	console.log( `--- Preparing package environment for React v${ version } ---` );
 
-	execNpmCommand( `install react@${ version } react-dom@${ version } --legacy-peer-deps`, TESTS_PATH );
+	execNpmCommand(
+		`install react@${ version } react-dom@${ version } --legacy-peer-deps`,
+		TESTS_PATH
+	);
 }
 
 /**
@@ -164,11 +168,20 @@ function cleanupTestDir() {
 		'package.json',
 		'webpack.config.js',
 		'karma.conf.js',
-		'scripts/test-transpiler.js'
+		'scripts/test-transpiler.js',
+		'src/ckeditor.jsx',
+		'tests/browser/ckeditor.jsx',
+		'tests/server/ckeditor.jsx',
+		'tests/utils/polyfill.js'
 	];
 
 	rmdirSyncRecursive( TESTS_PATH );
 	mkdirSync( TESTS_PATH );
+	mkdirSync( `${ TESTS_PATH }/src` );
+	mkdirSync( `${ TESTS_PATH }/tests` );
+	mkdirSync( `${ TESTS_PATH }/tests/browser` );
+	mkdirSync( `${ TESTS_PATH }/tests/server` );
+	mkdirSync( `${ TESTS_PATH }/tests/utils` );
 	mkdirSync( `${ TESTS_PATH }/scripts` );
 
 	copyFiles( filesToCopy, PACKAGE_PATH, TESTS_PATH );
@@ -185,10 +198,17 @@ function testVersion( version ) {
 	try {
 		console.log( `--- Testing React v${ version } ---` );
 
+		process.env.REQUESTED_REACT_VERSION = version;
+
 		if ( testedBrowser === 'SSR' ) {
-			console.log( execNpmCommand( 'run test:ssr' ) );
+			console.log( execNpmCommand( 'run test:ssr', TESTS_PATH ) );
 		} else {
-			console.log( execNpmCommand( `run test:browser -- --browsers ${ testedBrowser }` ) );
+			console.log(
+				execNpmCommand(
+					`run test:browser -- --browsers ${ testedBrowser }`,
+					TESTS_PATH
+				)
+			);
 		}
 
 		versionsPassed.push( version );

--- a/tests/browser/ckeditor.jsx
+++ b/tests/browser/ckeditor.jsx
@@ -73,17 +73,17 @@ describe( 'CKEditor Component', () => {
 	} );
 
 	// (#204)
-	const requestedVersion = process.env.REQUESTED_REACT_VERSION;
-
-	it( `uses requested React v${ requestedVersion }`, () => {
+	it( 'uses requested React', () => {
+		const requestedVersion = process.env.REQUESTED_REACT_VERSION;
 		const runningVersion = React.version;
 
 		if ( !requestedVersion ) {
 			console.warn(
 				`REQUESTED_REACT_VERSION variable was not set. Running tests for React v${ runningVersion }`
 			);
+		} else {
+			expect( requestedVersion ).to.equal( runningVersion );
 		}
-		expect( requestedVersion ).to.equal( runningVersion );
 	} );
 
 	describe( 'mounting and types', () => {

--- a/tests/browser/ckeditor.jsx
+++ b/tests/browser/ckeditor.jsx
@@ -8,6 +8,8 @@
 
 import sinonChai from 'sinon-chai';
 import React from 'react';
+/* global process */
+
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
@@ -68,6 +70,20 @@ describe( 'CKEditor Component', () => {
 	// (#48)
 	it( 'has proper displayName property', () => {
 		expect( CKEditor.displayName ).to.equal( 'CKEditor' );
+	} );
+
+	// (#204)
+	const requestedVersion = process.env.REQUESTED_REACT_VERSION;
+
+	it( `uses requested React v${ requestedVersion }`, () => {
+		const runningVersion = React.version;
+
+		if ( !requestedVersion ) {
+			console.warn(
+				`REQUESTED_REACT_VERSION variable was not set. Running tests for React v${ runningVersion }`
+			);
+		}
+		expect( requestedVersion ).to.equal( runningVersion );
 	} );
 
 	describe( 'mounting and types', () => {


### PR DESCRIPTION
This PR accomplishes the following:

- fixes `react-tester` so that requested React version is always tested
- adds test case to verify that requested and runtime React versions are equal

Closes #204.