### PR TITLE
Provide code samples for easier issue reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,7 +17,7 @@ decrease the time needed to reproduce the issue by our team, which means it can 
 You can use one of our samples to create the reproduction sample:
 
 * CodeSandbox: https://codesandbox.io/s/kjqil
-* StackBlitz: https://stackblitz.com/edit/react-kedrzm
+* StackBlitz: https://stackblitz.com/edit/ckeditor4-react-bug-report
 -->
 
 1. …

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -16,6 +16,8 @@ decrease the time needed to reproduce the issue by our team, which means it can 
 
 You can use one of our samples to create the reproduction sample:
 
+For v1.x use those samples and for v2.x fork those provided in the repo.
+
 * CodeSandbox: https://codesandbox.io/s/kjqil
 * StackBlitz: https://stackblitz.com/edit/ckeditor4-react-bug-report
 -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,6 +10,16 @@ Replace this comment with your issue type: Bug / Feature request / Other, please
 
 ## Provide detailed reproduction steps (if any)
 
+<!--
+Including a simple sample reproducing the issue is also a good idea. It can drastically
+decrease the time needed to reproduce the issue by our team, which means it can speed up helping you!
+
+You can use one of our samples to create the reproduction sample:
+
+* CodeSandbox: https://codesandbox.io/s/kjqil
+* StackBlitz: https://stackblitz.com/edit/react-kedrzm
+-->
+
 1. …
 2. …
 3. …

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,7 +14,7 @@ Replace this comment with your issue type: Bug / Feature request / Other, please
 Including a simple sample reproducing the issue is also a good idea. It can drastically
 decrease the time needed for debugging by our team, which means it can speed up helping you!
 
-You can use one of our samples to create the reproduction sample:
+You can use one of our samples to create the reproduction sample (use those samples for v1.x. For v2.x use ones provided in the repository):
 
 * CodeSandbox: https://codesandbox.io/s/kjqil
 * StackBlitz: https://stackblitz.com/edit/ckeditor4-react-bug-report

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,11 +12,9 @@ Replace this comment with your issue type: Bug / Feature request / Other, please
 
 <!--
 Including a simple sample reproducing the issue is also a good idea. It can drastically
-decrease the time needed to reproduce the issue by our team, which means it can speed up helping you!
+decrease the time needed for debugging by our team, which means it can speed up helping you!
 
 You can use one of our samples to create the reproduction sample:
-
-For v1.x use those samples and for v2.x fork those provided in the repo.
 
 * CodeSandbox: https://codesandbox.io/s/kjqil
 * StackBlitz: https://stackblitz.com/edit/ckeditor4-react-bug-report


### PR DESCRIPTION
I've provide code samples from `CodeSandbox` and `StackBlitz` for easier issue reporting.

Closes [#170](https://github.com/ckeditor/ckeditor4-react/issues/170).
