### PR TITLE
Add changelog entires for RC versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # CKEditor 4 WYSIWYG Editor React Integration Changelog
 
+## ckeditor4-react 2.0.0-rc.1
+
+Other Changes:
+
+* Added CHANGELOG entries for RC versions.
+* Improved project README.
+
+## ckeditor4-react 2.0.0-rc.0
+
+BREAKING CHANGES:
+
+* [#124](https://github.com/ckeditor/ckeditor4-react/issues/124): Introduced support for React hooks and rewrote the component to use hooks internally.
+
+New Features:
+
+* [#159](https://github.com/ckeditor/ckeditor4-react/issues/159): Introduced support for React 17+ versions.
+* [#82](https://github.com/ckeditor/ckeditor4-react/issues/82): Introduced TypeScript support.
+* [#180](https://github.com/ckeditor/ckeditor4-react/issues/180): Introduced support for consumption of a "non-webpacked" package version.
+
 ## ckeditor4-react 1.4.2
 
 Other Changes:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Official [CKEditor 4](https://ckeditor.com/ckeditor-4/) WYSIWYG editor component
 
 We are looking forward to your feedback! You can report any issues, ideas or feature requests on the [integration issues page](https://github.com/ckeditor/ckeditor4-react/issues/new).
 
-**This is the RC version (Release Candidate) of the upcoming `major` version which provides support for React 17 and React hooks.** See [`stable` version here](https://www.npmjs.com/package/ckeditor4-react).
+**This is the RC version (Release Candidate) of the upcoming `major` version that provides support for React 17 and React hooks.** See [`stable` version here](https://www.npmjs.com/package/ckeditor4-react/v/1.4.2).
 
 ![CKEditor 4 screenshot](https://c.cksource.com/a/1/img/npm/ckeditor4.png)
 


### PR DESCRIPTION
Since `rc.0` is already there, the `rc.1` version is the one fixing changelog.