### PR TITLE
Upgrade ckeditor4-integrations common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CKEditor 4 WYSIWYG Editor React Integration Changelog
 
+## ckeditor4-react 2.0.0-rc.2
+
+BREAKING CHANGES:
+
+* [#226](https://github.com/ckeditor/ckeditor4-react/issues/226): Updated `ckeditor4-integrations-common` dependency to version `1.0.0`.
+
 ## ckeditor4-react 2.0.0-rc.1
 
 Other Changes:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The CKEditor 4 React component works with React starting from 16.8.3 version inc
 
 ## Browser support
 
-The CKEditor 4 React component works with all the [supported browsers](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_browsers.html#officially-supported-browsers) except for Internet Explorer 8-10.
+The CKEditor 4 React component works with all the [supported browsers](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_browsers.html#officially-supported-browsers) except for Internet Explorer 8-10. For Internet Explorer 11 the component requires additional polyfill for `Promise`.
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2502,12 +2502,9 @@
 			"dev": true
 		},
 		"ckeditor4-integrations-common": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
-			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
-			"requires": {
-				"load-script": "^1.0.0"
-			}
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-1.0.0.tgz",
+			"integrity": "sha512-OAoQT/gYrHkg0qgzf6MS/rndYhq3SScLVQ3rtXQeuCE8ju7nFHg3qZ7WGA2XpFxcZzsMP6hhugXqdel5vbcC3g=="
 		},
 		"cli-cursor": {
 			"version": "3.1.0",
@@ -4585,11 +4582,6 @@
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
 			}
-		},
-		"load-script": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
 		},
 		"locate-path": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
 		"typescript": "^4.2.4"
 	},
 	"dependencies": {
-		"ckeditor4-integrations-common": "^0.2.0",
+		"ckeditor4-integrations-common": "^1.0.0",
 		"prop-types": "^15.7.2"
 	}
 }

--- a/samples/basic-typescript/package-lock.json
+++ b/samples/basic-typescript/package-lock.json
@@ -1919,23 +1919,6 @@
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true
 		},
-		"ckeditor4-integrations-common": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
-			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
-			"requires": {
-				"load-script": "^1.0.0"
-			}
-		},
-		"ckeditor4-react": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-1.4.1.tgz",
-			"integrity": "sha512-2CA89wcmXOEmfLS47jFRJ1xFDEqg1q5oxnwiu33vrgk0ewxf0dgxfue4uthSjNUQ6M4pNu4rtIiIXZ5kUSojnA==",
-			"requires": {
-				"ckeditor4-integrations-common": "^0.2.0",
-				"prop-types": "^15.6.2"
-			}
-		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -2180,6 +2163,11 @@
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
+		},
+		"core-js": {
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.0.tgz",
+			"integrity": "sha512-GUbtPllXMYRzIgHNZ4dTYTcUemls2cni83Q4Q/TrFONHfhcg9oEGOtaGHfb0cpzec60P96UKPvMkjX1jET8rUw=="
 		},
 		"core-js-compat": {
 			"version": "3.11.1",
@@ -4093,11 +4081,6 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
-		"load-script": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
-		},
 		"loader-runner": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4900,16 +4883,6 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
-		"prop-types": {
-			"version": "15.7.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-			"requires": {
-				"loose-envify": "^1.4.0",
-				"object-assign": "^4.1.1",
-				"react-is": "^16.8.1"
-			}
-		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -5132,11 +5105,6 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
 			"integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
 			"dev": true
-		},
-		"react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",

--- a/samples/basic-typescript/package.json
+++ b/samples/basic-typescript/package.json
@@ -11,6 +11,7 @@
 	],
 	"dependencies": {
 		"ckeditor4-react": "latest",
+		"core-js": "^3.15.0",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2"
 	},

--- a/samples/basic-typescript/src/index.tsx
+++ b/samples/basic-typescript/src/index.tsx
@@ -1,3 +1,6 @@
+// IE11 polyfills
+import 'core-js/stable/promise';
+
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import App from './App';

--- a/samples/basic/package-lock.json
+++ b/samples/basic/package-lock.json
@@ -1891,23 +1891,6 @@
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true
 		},
-		"ckeditor4-integrations-common": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
-			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
-			"requires": {
-				"load-script": "^1.0.0"
-			}
-		},
-		"ckeditor4-react": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-1.4.1.tgz",
-			"integrity": "sha512-2CA89wcmXOEmfLS47jFRJ1xFDEqg1q5oxnwiu33vrgk0ewxf0dgxfue4uthSjNUQ6M4pNu4rtIiIXZ5kUSojnA==",
-			"requires": {
-				"ckeditor4-integrations-common": "^0.2.0",
-				"prop-types": "^15.6.2"
-			}
-		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -2152,6 +2135,11 @@
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
+		},
+		"core-js": {
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.0.tgz",
+			"integrity": "sha512-GUbtPllXMYRzIgHNZ4dTYTcUemls2cni83Q4Q/TrFONHfhcg9oEGOtaGHfb0cpzec60P96UKPvMkjX1jET8rUw=="
 		},
 		"core-js-compat": {
 			"version": "3.10.1",
@@ -4034,11 +4022,6 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
-		"load-script": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
-		},
 		"loader-runner": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4832,16 +4815,6 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
-		"prop-types": {
-			"version": "15.7.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-			"requires": {
-				"loose-envify": "^1.4.0",
-				"object-assign": "^4.1.1",
-				"react-is": "^16.8.1"
-			}
-		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -5064,11 +5037,6 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
 			"integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
 			"dev": true
-		},
-		"react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",

--- a/samples/basic/package.json
+++ b/samples/basic/package.json
@@ -11,6 +11,7 @@
 	],
 	"dependencies": {
 		"ckeditor4-react": "latest",
+		"core-js": "^3.15.0",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2"
 	},

--- a/samples/basic/src/index.jsx
+++ b/samples/basic/src/index.jsx
@@ -1,3 +1,6 @@
+// IE11 polyfills
+import 'core-js/stable/promise';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';

--- a/samples/component-events/package-lock.json
+++ b/samples/component-events/package-lock.json
@@ -1891,23 +1891,6 @@
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true
 		},
-		"ckeditor4-integrations-common": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
-			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
-			"requires": {
-				"load-script": "^1.0.0"
-			}
-		},
-		"ckeditor4-react": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-1.4.2.tgz",
-			"integrity": "sha512-4H5ZRCLBWoAaOVN+u+3bMXGOaq0n+FlYvHiH7F4FAIbxDXPSyDweQiTdMS74au/neOJffGY8mLtqf2nIP9wr7g==",
-			"requires": {
-				"ckeditor4-integrations-common": "^0.2.0",
-				"prop-types": "^15.6.2"
-			}
-		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -2152,6 +2135,11 @@
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
+		},
+		"core-js": {
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.0.tgz",
+			"integrity": "sha512-GUbtPllXMYRzIgHNZ4dTYTcUemls2cni83Q4Q/TrFONHfhcg9oEGOtaGHfb0cpzec60P96UKPvMkjX1jET8rUw=="
 		},
 		"core-js-compat": {
 			"version": "3.10.1",
@@ -4034,11 +4022,6 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
-		"load-script": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
-		},
 		"loader-runner": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4832,16 +4815,6 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
-		"prop-types": {
-			"version": "15.7.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-			"requires": {
-				"loose-envify": "^1.4.0",
-				"object-assign": "^4.1.1",
-				"react-is": "^16.8.1"
-			}
-		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -5064,11 +5037,6 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
 			"integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
 			"dev": true
-		},
-		"react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",

--- a/samples/component-events/package.json
+++ b/samples/component-events/package.json
@@ -11,6 +11,7 @@
 	],
 	"dependencies": {
 		"ckeditor4-react": "latest",
+		"core-js": "^3.15.0",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2"
 	},

--- a/samples/component-events/src/index.jsx
+++ b/samples/component-events/src/index.jsx
@@ -1,3 +1,6 @@
+// IE11 polyfills
+import 'core-js/stable/promise';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';

--- a/samples/component/package-lock.json
+++ b/samples/component/package-lock.json
@@ -1891,23 +1891,6 @@
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true
 		},
-		"ckeditor4-integrations-common": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
-			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
-			"requires": {
-				"load-script": "^1.0.0"
-			}
-		},
-		"ckeditor4-react": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-1.4.2.tgz",
-			"integrity": "sha512-4H5ZRCLBWoAaOVN+u+3bMXGOaq0n+FlYvHiH7F4FAIbxDXPSyDweQiTdMS74au/neOJffGY8mLtqf2nIP9wr7g==",
-			"requires": {
-				"ckeditor4-integrations-common": "^0.2.0",
-				"prop-types": "^15.6.2"
-			}
-		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -2152,6 +2135,11 @@
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
+		},
+		"core-js": {
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.0.tgz",
+			"integrity": "sha512-GUbtPllXMYRzIgHNZ4dTYTcUemls2cni83Q4Q/TrFONHfhcg9oEGOtaGHfb0cpzec60P96UKPvMkjX1jET8rUw=="
 		},
 		"core-js-compat": {
 			"version": "3.10.1",
@@ -4034,11 +4022,6 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
-		"load-script": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
-		},
 		"loader-runner": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4832,16 +4815,6 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
-		"prop-types": {
-			"version": "15.7.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-			"requires": {
-				"loose-envify": "^1.4.0",
-				"object-assign": "^4.1.1",
-				"react-is": "^16.8.1"
-			}
-		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -5064,11 +5037,6 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
 			"integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
 			"dev": true
-		},
-		"react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",

--- a/samples/component/package.json
+++ b/samples/component/package.json
@@ -11,6 +11,7 @@
 	],
 	"dependencies": {
 		"ckeditor4-react": "latest",
+		"core-js": "^3.15.0",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2"
 	},

--- a/samples/component/src/index.jsx
+++ b/samples/component/src/index.jsx
@@ -1,3 +1,6 @@
+// IE11 polyfills
+import 'core-js/stable/promise';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';

--- a/samples/hook-events/package-lock.json
+++ b/samples/hook-events/package-lock.json
@@ -1891,23 +1891,6 @@
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true
 		},
-		"ckeditor4-integrations-common": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
-			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
-			"requires": {
-				"load-script": "^1.0.0"
-			}
-		},
-		"ckeditor4-react": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-1.4.2.tgz",
-			"integrity": "sha512-4H5ZRCLBWoAaOVN+u+3bMXGOaq0n+FlYvHiH7F4FAIbxDXPSyDweQiTdMS74au/neOJffGY8mLtqf2nIP9wr7g==",
-			"requires": {
-				"ckeditor4-integrations-common": "^0.2.0",
-				"prop-types": "^15.6.2"
-			}
-		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -2152,6 +2135,11 @@
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
+		},
+		"core-js": {
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.0.tgz",
+			"integrity": "sha512-GUbtPllXMYRzIgHNZ4dTYTcUemls2cni83Q4Q/TrFONHfhcg9oEGOtaGHfb0cpzec60P96UKPvMkjX1jET8rUw=="
 		},
 		"core-js-compat": {
 			"version": "3.10.1",
@@ -4034,11 +4022,6 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
-		"load-script": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
-		},
 		"loader-runner": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4832,16 +4815,6 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
-		"prop-types": {
-			"version": "15.7.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-			"requires": {
-				"loose-envify": "^1.4.0",
-				"object-assign": "^4.1.1",
-				"react-is": "^16.8.1"
-			}
-		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -5064,11 +5037,6 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
 			"integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
 			"dev": true
-		},
-		"react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",

--- a/samples/hook-events/package.json
+++ b/samples/hook-events/package.json
@@ -11,6 +11,7 @@
 	],
 	"dependencies": {
 		"ckeditor4-react": "latest",
+		"core-js": "^3.15.0",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2"
 	},

--- a/samples/hook-events/src/index.jsx
+++ b/samples/hook-events/src/index.jsx
@@ -1,3 +1,6 @@
+// IE11 polyfills
+import 'core-js/stable/promise';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';

--- a/samples/hook/package-lock.json
+++ b/samples/hook/package-lock.json
@@ -1891,23 +1891,6 @@
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true
 		},
-		"ckeditor4-integrations-common": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
-			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
-			"requires": {
-				"load-script": "^1.0.0"
-			}
-		},
-		"ckeditor4-react": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-1.4.1.tgz",
-			"integrity": "sha512-2CA89wcmXOEmfLS47jFRJ1xFDEqg1q5oxnwiu33vrgk0ewxf0dgxfue4uthSjNUQ6M4pNu4rtIiIXZ5kUSojnA==",
-			"requires": {
-				"ckeditor4-integrations-common": "^0.2.0",
-				"prop-types": "^15.6.2"
-			}
-		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -2152,6 +2135,11 @@
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
+		},
+		"core-js": {
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.0.tgz",
+			"integrity": "sha512-GUbtPllXMYRzIgHNZ4dTYTcUemls2cni83Q4Q/TrFONHfhcg9oEGOtaGHfb0cpzec60P96UKPvMkjX1jET8rUw=="
 		},
 		"core-js-compat": {
 			"version": "3.10.1",
@@ -4034,11 +4022,6 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
-		"load-script": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
-		},
 		"loader-runner": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4832,16 +4815,6 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
-		"prop-types": {
-			"version": "15.7.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-			"requires": {
-				"loose-envify": "^1.4.0",
-				"object-assign": "^4.1.1",
-				"react-is": "^16.8.1"
-			}
-		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -5064,11 +5037,6 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
 			"integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
 			"dev": true
-		},
-		"react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",

--- a/samples/hook/package.json
+++ b/samples/hook/package.json
@@ -11,6 +11,7 @@
 	],
 	"dependencies": {
 		"ckeditor4-react": "latest",
+		"core-js": "^3.15.0",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2"
 	},

--- a/samples/hook/src/index.jsx
+++ b/samples/hook/src/index.jsx
@@ -1,3 +1,6 @@
+// IE11 polyfills
+import 'core-js/stable/promise';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';

--- a/samples/re-order/package-lock.json
+++ b/samples/re-order/package-lock.json
@@ -1891,23 +1891,6 @@
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true
 		},
-		"ckeditor4-integrations-common": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
-			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
-			"requires": {
-				"load-script": "^1.0.0"
-			}
-		},
-		"ckeditor4-react": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-1.4.2.tgz",
-			"integrity": "sha512-4H5ZRCLBWoAaOVN+u+3bMXGOaq0n+FlYvHiH7F4FAIbxDXPSyDweQiTdMS74au/neOJffGY8mLtqf2nIP9wr7g==",
-			"requires": {
-				"ckeditor4-integrations-common": "^0.2.0",
-				"prop-types": "^15.6.2"
-			}
-		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -2152,6 +2135,11 @@
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
+		},
+		"core-js": {
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.0.tgz",
+			"integrity": "sha512-GUbtPllXMYRzIgHNZ4dTYTcUemls2cni83Q4Q/TrFONHfhcg9oEGOtaGHfb0cpzec60P96UKPvMkjX1jET8rUw=="
 		},
 		"core-js-compat": {
 			"version": "3.10.1",
@@ -4034,11 +4022,6 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
-		"load-script": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
-		},
 		"loader-runner": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4832,16 +4815,6 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
-		"prop-types": {
-			"version": "15.7.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-			"requires": {
-				"loose-envify": "^1.4.0",
-				"object-assign": "^4.1.1",
-				"react-is": "^16.8.1"
-			}
-		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -5064,11 +5037,6 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
 			"integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
 			"dev": true
-		},
-		"react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",

--- a/samples/re-order/package.json
+++ b/samples/re-order/package.json
@@ -11,6 +11,7 @@
 	],
 	"dependencies": {
 		"ckeditor4-react": "latest",
+		"core-js": "^3.15.0",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2"
 	},

--- a/samples/re-order/src/index.jsx
+++ b/samples/re-order/src/index.jsx
@@ -1,3 +1,6 @@
+// IE11 polyfills
+import 'core-js/stable/promise';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';

--- a/samples/ssr/package-lock.json
+++ b/samples/ssr/package-lock.json
@@ -1864,23 +1864,6 @@
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true
 		},
-		"ckeditor4-integrations-common": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
-			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
-			"requires": {
-				"load-script": "^1.0.0"
-			}
-		},
-		"ckeditor4-react": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-1.4.1.tgz",
-			"integrity": "sha512-2CA89wcmXOEmfLS47jFRJ1xFDEqg1q5oxnwiu33vrgk0ewxf0dgxfue4uthSjNUQ6M4pNu4rtIiIXZ5kUSojnA==",
-			"requires": {
-				"ckeditor4-integrations-common": "^0.2.0",
-				"prop-types": "^15.6.2"
-			}
-		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -2103,6 +2086,11 @@
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
+		},
+		"core-js": {
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.0.tgz",
+			"integrity": "sha512-GUbtPllXMYRzIgHNZ4dTYTcUemls2cni83Q4Q/TrFONHfhcg9oEGOtaGHfb0cpzec60P96UKPvMkjX1jET8rUw=="
 		},
 		"core-js-compat": {
 			"version": "3.10.1",
@@ -3779,11 +3767,6 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
-		"load-script": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
-		},
 		"loader-runner": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4509,16 +4492,6 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
-		"prop-types": {
-			"version": "15.7.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-			"requires": {
-				"loose-envify": "^1.4.0",
-				"object-assign": "^4.1.1",
-				"react-is": "^16.8.1"
-			}
-		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -4736,11 +4709,6 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
 			"integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
 			"dev": true
-		},
-		"react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",

--- a/samples/ssr/package.json
+++ b/samples/ssr/package.json
@@ -12,6 +12,7 @@
 	],
 	"dependencies": {
 		"ckeditor4-react": "latest",
+		"core-js": "^3.15.0",
 		"express": "^4.17.1",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2"

--- a/samples/ssr/src/index.jsx
+++ b/samples/ssr/src/index.jsx
@@ -1,3 +1,6 @@
+// IE11 polyfills
+import 'core-js/stable/promise';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';

--- a/samples/state-lifting/package-lock.json
+++ b/samples/state-lifting/package-lock.json
@@ -1891,23 +1891,6 @@
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true
 		},
-		"ckeditor4-integrations-common": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
-			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
-			"requires": {
-				"load-script": "^1.0.0"
-			}
-		},
-		"ckeditor4-react": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-1.4.2.tgz",
-			"integrity": "sha512-4H5ZRCLBWoAaOVN+u+3bMXGOaq0n+FlYvHiH7F4FAIbxDXPSyDweQiTdMS74au/neOJffGY8mLtqf2nIP9wr7g==",
-			"requires": {
-				"ckeditor4-integrations-common": "^0.2.0",
-				"prop-types": "^15.6.2"
-			}
-		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -2152,6 +2135,11 @@
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
+		},
+		"core-js": {
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.0.tgz",
+			"integrity": "sha512-GUbtPllXMYRzIgHNZ4dTYTcUemls2cni83Q4Q/TrFONHfhcg9oEGOtaGHfb0cpzec60P96UKPvMkjX1jET8rUw=="
 		},
 		"core-js-compat": {
 			"version": "3.10.1",
@@ -4034,11 +4022,6 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
-		"load-script": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
-		},
 		"loader-runner": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4832,16 +4815,6 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
-		"prop-types": {
-			"version": "15.7.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-			"requires": {
-				"loose-envify": "^1.4.0",
-				"object-assign": "^4.1.1",
-				"react-is": "^16.8.1"
-			}
-		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -5064,11 +5037,6 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
 			"integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
 			"dev": true
-		},
-		"react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",

--- a/samples/state-lifting/package.json
+++ b/samples/state-lifting/package.json
@@ -11,6 +11,7 @@
 	],
 	"dependencies": {
 		"ckeditor4-react": "latest",
+		"core-js": "^3.15.0",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2"
 	},

--- a/samples/state-lifting/src/index.jsx
+++ b/samples/state-lifting/src/index.jsx
@@ -1,3 +1,6 @@
+// IE11 polyfills
+import 'core-js/stable/promise';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';

--- a/samples/umd/package-lock.json
+++ b/samples/umd/package-lock.json
@@ -38,12 +38,12 @@
 			}
 		},
 		"ckeditor4-react": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-1.4.1.tgz",
-			"integrity": "sha512-2CA89wcmXOEmfLS47jFRJ1xFDEqg1q5oxnwiu33vrgk0ewxf0dgxfue4uthSjNUQ6M4pNu4rtIiIXZ5kUSojnA==",
+			"version": "2.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-2.0.0-rc.1.tgz",
+			"integrity": "sha512-h/1guTQvEHAFyTtigLRXZiLU84vwK3I0wA9YD6TDFl9HETT96iTw1+BxszHyA3oIHKmIFTaGcQNyVK6XN4yUOQ==",
 			"requires": {
 				"ckeditor4-integrations-common": "^0.2.0",
-				"prop-types": "^15.6.2"
+				"prop-types": "^15.7.2"
 			}
 		},
 		"colors": {

--- a/samples/umd/src/index.html
+++ b/samples/umd/src/index.html
@@ -15,6 +15,7 @@
 	</head>
 	<body>
 		<div id="root"></div>
+		<script src="https://cdn.jsdelivr.net/npm/es6-promise/dist/es6-promise.auto.min.js"></script>
 		<script src="react.production.min.js"></script>
 		<script src="react-dom.production.min.js"></script>
 		<script src="index.umd.development.js"></script>


### PR DESCRIPTION
Within this PR the following has been done:

*   `ckeditor4-integrations-common` package has been upgraded to `1.0.0`
*   polyfill of `Promise` was added to each sample in order to support IE11

Closes #226.