### PR TITLE
feat(v2): support markup within string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CKEditor 4 WYSIWYG Editor React Integration Changelog
 
+## ckeditor4-react 2.0.0-rc.3
+
+* [#228](https://github.com/ckeditor/ckeditor4-react/issues/226): Added support for setting editor's initial data as HTML string.
+
 ## ckeditor4-react 2.0.0-rc.2
 
 BREAKING CHANGES:

--- a/samples/basic/src/App.jsx
+++ b/samples/basic/src/App.jsx
@@ -1,11 +1,24 @@
 import React from 'react';
 import { CKEditor } from 'ckeditor4-react';
 
+/**
+ * `initData` can be either string with markup or JSX:
+ *
+ * <CKEditor initData="<p>Hello <strong>world</strong>!</p>" />
+ *
+ * Or:
+ *
+ * <CKEditor initData={<p>Hello <strong>world</strong>!</p>} />
+ *
+ */
 function App() {
 	return (
 		<div>
 			<section>
-				<CKEditor debug={true} initData="Hello world!" />
+				<CKEditor
+					debug={true}
+					initData="<p>Hello <strong>world</strong>!</p>"
+				/>
 			</section>
 			<footer>{`Running React v${ React.version }`}</footer>
 		</div>

--- a/src/CKEditor.tsx
+++ b/src/CKEditor.tsx
@@ -78,6 +78,12 @@ function CKEditor<EventHandlerProp>( {
 		element,
 
 		/**
+		 * String nodes are handled by the hook.
+		 * `initData` as JSX is handled in the component.
+		 */
+		initContent: typeof initData === 'string' ? initData : undefined,
+
+		/**
 		 * Subscribe only to those events for which handler was supplied.
 		 */
 		subscribeTo: Object.keys( handlers )
@@ -125,7 +131,7 @@ function CKEditor<EventHandlerProp>( {
 			ref={setElement}
 			style={getStyle( type ?? 'classic', status, style )}
 		>
-			{initData}
+			{typeof initData === 'string' ? null : initData}
 		</div>
 	);
 }
@@ -153,7 +159,6 @@ const propTypes = {
 
 	/**
 	 * Initial data will be set only once during editor instance's lifecycle.
-	 *
 	 */
 	initData: PropTypes.node,
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,6 +139,11 @@ export interface CKEditorHookProps<EventName extends string> {
 	element: HTMLElement | null;
 
 	/**
+	 * Initial editor content. Only `string` values are accepted.
+	 */
+	initContent?: string | null;
+
+	/**
 	 * Initializes editor in either `classic` or `inline` mode.
 	 *
 	 * See:

--- a/src/useCKEditor.ts
+++ b/src/useCKEditor.ts
@@ -186,9 +186,16 @@ function useCKEditor<EditorEvent extends string>( {
 						if ( initContentRef.current ) {
 							editor.setData( initContentRef.current, {
 								/**
-								 * Do not populate undo stack.
+								 * Prevents undo icon flickering.
 								 */
-								noSnapshot: true
+								noSnapshot: true,
+
+								/**
+								 * Resets undo stack.
+								 */
+								callback: () => {
+									editor.resetUndo();
+								}
 							} );
 						}
 					},

--- a/src/useCKEditor.ts
+++ b/src/useCKEditor.ts
@@ -39,6 +39,7 @@ function useCKEditor<EditorEvent extends string>( {
 	subscribeTo = defaultEvents,
 	editorUrl,
 	element,
+	initContent,
 	type = 'classic'
 }: CKEditorHookProps<EditorEvent | CKEditorDefaultEvent> ): CKEditorHookResult {
 	/**
@@ -60,6 +61,11 @@ function useCKEditor<EditorEvent extends string>( {
 	 * Ensures referential stability of `dispatchEvent` between renders.
 	 */
 	const dispatchEventRef = useRef( dispatchEvent );
+
+	/**
+	 * Ensures referential stability of `initContent`.
+	 */
+	const initContentRef = useRef( initContent );
 
 	/**
 	 * Ensures referential stability of editor config.
@@ -158,7 +164,7 @@ function useCKEditor<EditorEvent extends string>( {
 				} );
 
 				/**
-				 * Registers `instanceReady` event for the sake of hook lifecycle.
+				 * Registers handler `instanceReady` event.
 				 */
 				registerEditorEventHandler( {
 					debug: debugRef.current,
@@ -172,6 +178,25 @@ function useCKEditor<EditorEvent extends string>( {
 						 */
 						if ( isInline && !isReadOnly ) {
 							editor.setReadOnly( false );
+						}
+
+						/**
+						 * Sets initial content of editor's instance if provided.
+						 */
+						if ( initContentRef.current ) {
+							editor.setData( initContentRef.current, {
+								/**
+								 * Prevents undo icon flickering.
+								 */
+								noSnapshot: true,
+
+								/**
+								 * Resets undo stack.
+								 */
+								callback: () => {
+									editor.resetUndo();
+								}
+							} );
 						}
 					},
 					priority: -1

--- a/src/useCKEditor.ts
+++ b/src/useCKEditor.ts
@@ -186,16 +186,9 @@ function useCKEditor<EditorEvent extends string>( {
 						if ( initContentRef.current ) {
 							editor.setData( initContentRef.current, {
 								/**
-								 * Prevents undo icon flickering.
+								 * Do not populate undo stack.
 								 */
-								noSnapshot: true,
-
-								/**
-								 * Resets undo stack.
-								 */
-								callback: () => {
-									editor.resetUndo();
-								}
+								noSnapshot: true
 							} );
 						}
 					},

--- a/tests/unit/CKEditor.test.tsx
+++ b/tests/unit/CKEditor.test.tsx
@@ -34,6 +34,16 @@ function init() {
 		} );
 
 		/**
+		 * Ensures that initial data is set - JSX.
+		 */
+		it( 'initializes classic editor with initial data as JSX', async () => {
+			render( <CKEditor initData={<p>Hello world!</p>} /> );
+			expect(
+				await findByClassicEditorContent( 'Hello world!' )
+			).toBeVisible();
+		} );
+
+		/**
 		 * Ensures that inline editor is initialized in writable mode.
 		 */
 		it( 'initializes inline editor', async () => {
@@ -46,6 +56,16 @@ function init() {
 		 */
 		it( 'initializes inline editor with initial data', async () => {
 			render( <CKEditor type="inline" initData="Hello world!" /> );
+			expect(
+				await findByInlineEditorContent( 'Hello world!' )
+			).toBeVisible();
+		} );
+
+		/**
+		 * Ensures that initial data is set - JSX.
+		 */
+		it( 'initializes inline editor with initial data as JSX', async () => {
+			render( <CKEditor type="inline" initData={<p>Hello world!</p>} /> );
 			expect(
 				await findByInlineEditorContent( 'Hello world!' )
 			).toBeVisible();

--- a/tests/unit/useCKEditor.test.tsx
+++ b/tests/unit/useCKEditor.test.tsx
@@ -1,5 +1,9 @@
 import { renderHook } from '@testing-library/react-hooks/dom';
-import { createDivRef, queryClassicEditor } from './utils';
+import {
+	createDivRef,
+	findByClassicEditorContent,
+	queryClassicEditor
+} from './utils';
 import { useCKEditor, CKEditorEventAction } from '../../src';
 
 function init() {
@@ -418,6 +422,26 @@ function init() {
 			);
 			expect( onCustomEvent ).toHaveBeenCalledTimes( 1 );
 			expect( onOtherEvent ).toHaveBeenCalledTimes( 0 );
+		} );
+
+		/**
+		 * Ensures that initial content is set.
+		 */
+		it( 'sets initial content', async () => {
+			const ref = createDivRef();
+			const { result, waitForValueToChange } = renderHook( () =>
+				useCKEditor( {
+					element: ref.current,
+					initContent: '<p>Initial content</p>'
+				} )
+			);
+			await waitForValueToChange(
+				() => result.current.status === 'ready',
+				{ timeout: 5000 }
+			);
+			expect(
+				await findByClassicEditorContent( 'Initial content' )
+			).toBeVisible();
 		} );
 	} );
 }


### PR DESCRIPTION
The goal of this PR was to add support for setting `initData` as string with markup. For now we support only JSX.

JSX (supported now):
```js
<CKEditor initData={<p>Hello <strong>world</strong>!</p>} />
```

Strings with markup (to be supported thanks to this PR):
```js
<CKEditor initData="<p>Hello <strong>world</strong>!</p>" />

```

I see few ways to achieve an interface like that.

1. Set `initData` with `editor.setData` if it's string with markup. Use `children` if `initData` is JSX. With this approach there are two different but complementary ways of setting initial data. It's a bit complex solution.

2. Transform `initData` to string with [renderToStaticMarkup](https://reactjs.org/docs/react-dom-server.html#rendertostaticmarkup) if it's JSX and then use `editor.setData`. This solution requires us to use `react-dom/server` in the browser which has disadvantages such as bigger library size and more complex dependencies.

3. Use `dangerouslySetInnerHTML` to set initial data if it's string with markup. Use `children` if `initData` is JSX. This is a potential security vulnerability because content would be rendered to DOM with `dangerouslySetInnerHTML`.

I decided to use approach 1. It's not ideal but I believe it's better than other solutions. I have purposefully added `initContent` prop to `useCKEditor` rather than naming it `initData`. It's conceptually different than prop in `CKEditor` component and it supports `string` only (no JSX).

Alternatively we can give up on supporting either JSX or strings with markup which would lead to simpler code. I believe though that there are valid use cases for both. JSX is a language of React, so developers might re-use their components within `initData`. Developers might also want to use strings with markup if it comes form external sources.

Closes #228.

