### PR TITLE
fix: upgrade React min version to 16.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See ready-to-fork examples in `samples` directory. Each sample is a self-contain
 
 ## React support
 
-The CKEditor 4 React component works with React starting from 16.8.3 version including 17+ versions.
+The CKEditor 4 React component works with React starting from 16.9 version including 17+ versions.
 
 ## Browser support
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 	"homepage": "https://github.com/ckeditor/ckeditor4-react#readme",
 	"peerDependencies": {
 		"ckeditor4": "^4.16.1",
-		"react": "^16.8.3 || ^17"
+		"react": "^16.9 || ^17"
 	},
 	"peerDependenciesMeta": {
 		"ckeditor4": {

--- a/samples/basic-typescript/package-lock.json
+++ b/samples/basic-typescript/package-lock.json
@@ -1919,6 +1919,23 @@
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true
 		},
+		"ckeditor4-integrations-common": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
+			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
+			"requires": {
+				"load-script": "^1.0.0"
+			}
+		},
+		"ckeditor4-react": {
+			"version": "2.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-2.0.0-rc.1.tgz",
+			"integrity": "sha512-h/1guTQvEHAFyTtigLRXZiLU84vwK3I0wA9YD6TDFl9HETT96iTw1+BxszHyA3oIHKmIFTaGcQNyVK6XN4yUOQ==",
+			"requires": {
+				"ckeditor4-integrations-common": "^0.2.0",
+				"prop-types": "^15.7.2"
+			}
+		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -4081,6 +4098,11 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
+		"load-script": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+		},
 		"loader-runner": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4883,6 +4905,16 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
+		"prop-types": {
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
+			}
+		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -5105,6 +5137,11 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
 			"integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
 			"dev": true
+		},
+		"react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",

--- a/samples/basic/package-lock.json
+++ b/samples/basic/package-lock.json
@@ -1891,6 +1891,23 @@
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true
 		},
+		"ckeditor4-integrations-common": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
+			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
+			"requires": {
+				"load-script": "^1.0.0"
+			}
+		},
+		"ckeditor4-react": {
+			"version": "2.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-2.0.0-rc.1.tgz",
+			"integrity": "sha512-h/1guTQvEHAFyTtigLRXZiLU84vwK3I0wA9YD6TDFl9HETT96iTw1+BxszHyA3oIHKmIFTaGcQNyVK6XN4yUOQ==",
+			"requires": {
+				"ckeditor4-integrations-common": "^0.2.0",
+				"prop-types": "^15.7.2"
+			}
+		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -4022,6 +4039,11 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
+		"load-script": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+		},
 		"loader-runner": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4815,6 +4837,16 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
+		"prop-types": {
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
+			}
+		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -5037,6 +5069,11 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
 			"integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
 			"dev": true
+		},
+		"react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",

--- a/samples/component-events/package-lock.json
+++ b/samples/component-events/package-lock.json
@@ -1891,6 +1891,23 @@
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true
 		},
+		"ckeditor4-integrations-common": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
+			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
+			"requires": {
+				"load-script": "^1.0.0"
+			}
+		},
+		"ckeditor4-react": {
+			"version": "2.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-2.0.0-rc.1.tgz",
+			"integrity": "sha512-h/1guTQvEHAFyTtigLRXZiLU84vwK3I0wA9YD6TDFl9HETT96iTw1+BxszHyA3oIHKmIFTaGcQNyVK6XN4yUOQ==",
+			"requires": {
+				"ckeditor4-integrations-common": "^0.2.0",
+				"prop-types": "^15.7.2"
+			}
+		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -4022,6 +4039,11 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
+		"load-script": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+		},
 		"loader-runner": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4815,6 +4837,16 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
+		"prop-types": {
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
+			}
+		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -5037,6 +5069,11 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
 			"integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
 			"dev": true
+		},
+		"react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",

--- a/samples/component/package-lock.json
+++ b/samples/component/package-lock.json
@@ -1891,6 +1891,23 @@
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true
 		},
+		"ckeditor4-integrations-common": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
+			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
+			"requires": {
+				"load-script": "^1.0.0"
+			}
+		},
+		"ckeditor4-react": {
+			"version": "2.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-2.0.0-rc.1.tgz",
+			"integrity": "sha512-h/1guTQvEHAFyTtigLRXZiLU84vwK3I0wA9YD6TDFl9HETT96iTw1+BxszHyA3oIHKmIFTaGcQNyVK6XN4yUOQ==",
+			"requires": {
+				"ckeditor4-integrations-common": "^0.2.0",
+				"prop-types": "^15.7.2"
+			}
+		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -4022,6 +4039,11 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
+		"load-script": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+		},
 		"loader-runner": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4815,6 +4837,16 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
+		"prop-types": {
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
+			}
+		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -5037,6 +5069,11 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
 			"integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
 			"dev": true
+		},
+		"react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",

--- a/samples/hook-events/package-lock.json
+++ b/samples/hook-events/package-lock.json
@@ -1891,6 +1891,23 @@
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true
 		},
+		"ckeditor4-integrations-common": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
+			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
+			"requires": {
+				"load-script": "^1.0.0"
+			}
+		},
+		"ckeditor4-react": {
+			"version": "2.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-2.0.0-rc.1.tgz",
+			"integrity": "sha512-h/1guTQvEHAFyTtigLRXZiLU84vwK3I0wA9YD6TDFl9HETT96iTw1+BxszHyA3oIHKmIFTaGcQNyVK6XN4yUOQ==",
+			"requires": {
+				"ckeditor4-integrations-common": "^0.2.0",
+				"prop-types": "^15.7.2"
+			}
+		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -4022,6 +4039,11 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
+		"load-script": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+		},
 		"loader-runner": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4815,6 +4837,16 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
+		"prop-types": {
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
+			}
+		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -5037,6 +5069,11 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
 			"integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
 			"dev": true
+		},
+		"react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",

--- a/samples/hook/package-lock.json
+++ b/samples/hook/package-lock.json
@@ -1891,6 +1891,23 @@
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true
 		},
+		"ckeditor4-integrations-common": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
+			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
+			"requires": {
+				"load-script": "^1.0.0"
+			}
+		},
+		"ckeditor4-react": {
+			"version": "2.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-2.0.0-rc.1.tgz",
+			"integrity": "sha512-h/1guTQvEHAFyTtigLRXZiLU84vwK3I0wA9YD6TDFl9HETT96iTw1+BxszHyA3oIHKmIFTaGcQNyVK6XN4yUOQ==",
+			"requires": {
+				"ckeditor4-integrations-common": "^0.2.0",
+				"prop-types": "^15.7.2"
+			}
+		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -4022,6 +4039,11 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
+		"load-script": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+		},
 		"loader-runner": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4815,6 +4837,16 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
+		"prop-types": {
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
+			}
+		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -5037,6 +5069,11 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
 			"integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
 			"dev": true
+		},
+		"react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",

--- a/samples/re-order/package-lock.json
+++ b/samples/re-order/package-lock.json
@@ -1891,6 +1891,23 @@
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true
 		},
+		"ckeditor4-integrations-common": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
+			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
+			"requires": {
+				"load-script": "^1.0.0"
+			}
+		},
+		"ckeditor4-react": {
+			"version": "2.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-2.0.0-rc.1.tgz",
+			"integrity": "sha512-h/1guTQvEHAFyTtigLRXZiLU84vwK3I0wA9YD6TDFl9HETT96iTw1+BxszHyA3oIHKmIFTaGcQNyVK6XN4yUOQ==",
+			"requires": {
+				"ckeditor4-integrations-common": "^0.2.0",
+				"prop-types": "^15.7.2"
+			}
+		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -4022,6 +4039,11 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
+		"load-script": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+		},
 		"loader-runner": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4815,6 +4837,16 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
+		"prop-types": {
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
+			}
+		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -5037,6 +5069,11 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
 			"integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
 			"dev": true
+		},
+		"react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",

--- a/samples/ssr/package-lock.json
+++ b/samples/ssr/package-lock.json
@@ -1864,6 +1864,23 @@
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true
 		},
+		"ckeditor4-integrations-common": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
+			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
+			"requires": {
+				"load-script": "^1.0.0"
+			}
+		},
+		"ckeditor4-react": {
+			"version": "2.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-2.0.0-rc.1.tgz",
+			"integrity": "sha512-h/1guTQvEHAFyTtigLRXZiLU84vwK3I0wA9YD6TDFl9HETT96iTw1+BxszHyA3oIHKmIFTaGcQNyVK6XN4yUOQ==",
+			"requires": {
+				"ckeditor4-integrations-common": "^0.2.0",
+				"prop-types": "^15.7.2"
+			}
+		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -3767,6 +3784,11 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
+		"load-script": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+		},
 		"loader-runner": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4492,6 +4514,16 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
+		"prop-types": {
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
+			}
+		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -4709,6 +4741,11 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
 			"integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
 			"dev": true
+		},
+		"react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",

--- a/samples/state-lifting/package-lock.json
+++ b/samples/state-lifting/package-lock.json
@@ -1891,6 +1891,23 @@
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true
 		},
+		"ckeditor4-integrations-common": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz",
+			"integrity": "sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==",
+			"requires": {
+				"load-script": "^1.0.0"
+			}
+		},
+		"ckeditor4-react": {
+			"version": "2.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-2.0.0-rc.1.tgz",
+			"integrity": "sha512-h/1guTQvEHAFyTtigLRXZiLU84vwK3I0wA9YD6TDFl9HETT96iTw1+BxszHyA3oIHKmIFTaGcQNyVK6XN4yUOQ==",
+			"requires": {
+				"ckeditor4-integrations-common": "^0.2.0",
+				"prop-types": "^15.7.2"
+			}
+		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -4022,6 +4039,11 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
+		"load-script": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+		},
 		"loader-runner": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4815,6 +4837,16 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
+		"prop-types": {
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
+			}
+		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -5037,6 +5069,11 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
 			"integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
 			"dev": true
+		},
+		"react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",


### PR DESCRIPTION
Upgrades min version of React inside `peerDependencies` to `^16.9`. Also, `package-lock.json` files inside samples were updated.

Closes #221.