### PR TITLE
Use detach/re-attach feature of editor's container

### DIFF
--- a/samples/re-order/src/App.jsx
+++ b/samples/re-order/src/App.jsx
@@ -5,40 +5,20 @@ const { version, useState } = React;
 
 const config = { height: 50, toolbar: [ [ 'Bold' ] ] };
 
-const initState = {
-	toast: 'toast',
-	bagel: 'bagel',
-	taco: 'taco',
-	avocado: 'avocado'
-};
-
 /**
- * Inline editors can be easily re-ordered.
+ * Since CKEditor v4.17, editor's container element can be detached and re-attached to DOM.
+ * Therefore, editor instances can be easily re-ordered.
  *
- * Please note that due to upstream issues classic editor must be re-initialized after re-ordering:
- * - https://github.com/ckeditor/ckeditor4/pull/4463
- * - https://github.com/ckeditor/ckeditor4/pull/4481
- *
- * This example uses a simple cache to re-initialize classic editor with previous data.
- *
+ * Prior to CKEditor v4.17, classic editor instance had to be re-created
+ * anytime editor's container element was being detached and re-attached to DOM.
  */
 function App() {
-	const [ order, setOrder ] = useState( Object.keys( initState ) );
-	const [ cache, setCache ] = useState( initState );
+	const [ order, setOrder ] = useState(
+		[ 'toast', 'bagel', 'taco', 'avocado' ]
+	);
 
 	const handleReorderClick = () => {
 		setOrder( current => shuffle( [ ...current ] ) );
-	};
-
-	const handleInstanceReady = ( { editor } ) => {
-		editor.setData( cache[ editor.name ] );
-	};
-
-	const handleDestroy = ( { editor } ) => {
-		setCache( current => ( {
-			...current,
-			[ editor.name ]: editor.getData()
-		} ) );
 	};
 
 	return (
@@ -52,14 +32,13 @@ function App() {
 						<div className="editors-group flex-grow-1">
 							<h4>{'Classic editors'}</h4>
 							{order.map( value => (
-								<div key={getUniqueName()}>
+								<div key={value}>
 									<CKEditor
 										name={value}
+										initData={value}
 										debug={true}
 										type="classic"
 										config={config}
-										onDestroy={handleDestroy}
-										onInstanceReady={handleInstanceReady}
 									/>
 								</div>
 							) )}
@@ -84,13 +63,6 @@ function App() {
 			<footer>{`Running React v${ version }`}</footer>
 		</div>
 	);
-}
-
-function getUniqueName() {
-	return Math.random()
-		.toString( 36 )
-		.replace( /[^a-z]+/g, '' )
-		.substr( 0, 5 );
 }
 
 function shuffle( array ) {


### PR DESCRIPTION
These changes simplify `re-order` sample. Since CKEditor v4.17 it's no longer necessary to re-create editor instances anytime the editor's container is being detached / re-attached to DOM.

Closes #109.