### PR TITLE
Use fixed version of Nightwatch.

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		"karma-mocha-reporter": "^2.2.5",
 		"karma-rollup-preprocessor": "^7.0.8",
 		"minimist": "^1.2.5",
-		"nightwatch": "^2.0.7",
+		"nightwatch": "2.0.10",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
 		"rollup": "^2.68.0",


### PR DESCRIPTION
I've tested locally recent versions of Nightwatch and it appears that versions since v2.1.x are problematic. Therefore, `nightwatch@2.0.10` is used as a temporary solution.

Closes #285.